### PR TITLE
Nest errors localization inside :activerecord to prevent translation missing errors.

### DIFF
--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -212,7 +212,7 @@ module ActionView
           end
           options[:object_name] ||= params.first
 
-          I18n.with_options :locale => options[:locale], :scope => [:errors, :template] do |locale|
+          I18n.with_options :locale => options[:locale], :scope => [:activerecord, :errors, :template] do |locale|
             header_message = if options.include?(:header_message)
               options[:header_message]
             else

--- a/lib/action_view/locale/en.yml
+++ b/lib/action_view/locale/en.yml
@@ -1,8 +1,9 @@
 en:
-  errors:
-    template:
-      header:
-        one:    "1 error prohibited this %{model} from being saved"
-        other:  "%{count} errors prohibited this %{model} from being saved"
-      # The variable :count is also available
-      body: "There were problems with the following fields:"
+  activerecord:
+    errors:
+      template:
+        header:
+          one:    "1 error prohibited this %{model} from being saved"
+          other:  "%{count} errors prohibited this %{model} from being saved"
+        # The variable :count is also available
+        body: "There were problems with the following fields:"

--- a/test/dynamic_form_i18n_test.rb
+++ b/test/dynamic_form_i18n_test.rb
@@ -16,27 +16,27 @@ class DynamicFormI18nTest < Test::Unit::TestCase
 
     stubs(:content_tag).returns 'content_tag'
 
-    I18n.stubs(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').returns "1 error prohibited this  from being saved"
-    I18n.stubs(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).returns 'There were problems with the following fields:'
+    I18n.stubs(:t).with(:'header', :locale => 'en', :scope => [:activerecord, :errors, :template], :count => 1, :model => '').returns "1 error prohibited this  from being saved"
+    I18n.stubs(:t).with(:'body', :locale => 'en', :scope => [:activerecord, :errors, :template]).returns 'There were problems with the following fields:'
   end
 
   def test_error_messages_for_given_a_header_option_it_does_not_translate_header_message
-    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').never
+    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:activerecord, :errors, :template], :count => 1, :model => '').never
     error_messages_for(:object => @object, :header_message => 'header message', :locale => 'en')
   end
 
   def test_error_messages_for_given_no_header_option_it_translates_header_message
-    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:errors, :template], :count => 1, :model => '').returns 'header message'
+    I18n.expects(:t).with(:'header', :locale => 'en', :scope => [:activerecord, :errors, :template], :count => 1, :model => '').returns 'header message'
     error_messages_for(:object => @object, :locale => 'en')
   end
 
   def test_error_messages_for_given_a_message_option_it_does_not_translate_message
-    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).never
+    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:activerecord, :errors, :template]).never
     error_messages_for(:object => @object, :message => 'message', :locale => 'en')
   end
 
   def test_error_messages_for_given_no_message_option_it_translates_message
-    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:errors, :template]).returns 'There were problems with the following fields:'
+    I18n.expects(:t).with(:'body', :locale => 'en', :scope => [:activerecord, :errors, :template]).returns 'There were problems with the following fields:'
     error_messages_for(:object => @object, :locale => 'en')
   end
 end


### PR DESCRIPTION
Change locale errors structure to match structure in rails 3 and rails-i18n. Avoids "translation missing" errors.

See https://github.com/rails/rails/blob/master/activerecord/lib/active_record/locale/en.yml#L8 and https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/en-US.yml#L168-174
