### PR TITLE
Correct  a possible typo  in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ DynamicForm holds a few helpers method to help you deal with your Rails3 models,
 * `error_message_on(object, method, options={})`
 * `error_messages_for(record, options={})`
 
-It also adds `f.error_messages` and `f.error_messages_on` to your form builders.
+It also adds `f.error_messages` and `f.error_message_on` to your form builders.
 
 Read `/lib/action_view/helpers/dynamic_form.rb` for details of each method.
 


### PR DESCRIPTION
I guess it is "f.error_message_on" here, not "f.error_messages_on". See the changes in diff.
