### PR TITLE
Only rewrite implied model names

### DIFF
--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -210,13 +210,13 @@ module ActionView
               html[key] = 'error_explanation'
             end
           end
-          options[:object_name] ||= params.first
+          options[:object_name] ||= params.first.to_s.gsub('_', ' ')
 
           I18n.with_options :locale => options[:locale], :scope => [:activerecord, :errors, :template] do |locale|
             header_message = if options.include?(:header_message)
               options[:header_message]
             else
-              locale.t :header, :count => count, :model => options[:object_name].to_s.gsub('_', ' ')
+              locale.t :header, :count => count, :model => options[:object_name].to_s
             end
 
             message = options.include?(:message) ? options[:message] : locale.t(:body)

--- a/test/dynamic_form_test.rb
+++ b/test/dynamic_form_test.rb
@@ -292,9 +292,6 @@ class DynamicFormTest < ActionView::TestCase
     # any default works too
     assert_dom_equal %(<div class="error_explanation" id="error_explanation"><h2>2 errors prohibited this monkey from being saved</h2><p>There were problems with the following fields:</p><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :object_name => "monkey")
 
-    # should space object name
-    assert_dom_equal %(<div class="error_explanation" id="error_explanation"><h2>2 errors prohibited this chunky bacon from being saved</h2><p>There were problems with the following fields:</p><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :object_name => "chunky_bacon")
-
     # hide header and explanation messages with nil or empty string
     assert_dom_equal %(<div class="error_explanation" id="error_explanation"><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :header_message => nil, :message => "")
 


### PR DESCRIPTION
If a model name comes from the translations (ie User.class.model_name.human)
or if it has been supplied by the user (options[:object_name]) then show it
as is.

Only rewrite underscores if it has been derived from the supplied model, i.e.

  error_messages_for :user
