### PR TITLE
Add license to gemspec.

### DIFF
--- a/dynamic_form.gemspec
+++ b/dynamic_form.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Joel Moss"]
   s.date = %q{2010-09-05}
+  s.license = "MIT"
   s.description = %q{DynamicForm holds a few helper methods to help you deal with your Rails3 models. It includes the stripped out methods from Rails 2; error_message_on and error_messages_for. It also brings in the functionality of the custom-err-messages plugin, which provides more flexibility over your model error messages.}
   s.email = %q{joel@developwithstyle.com}
   s.extra_rdoc_files = [


### PR DESCRIPTION
I'm working on the open source project [VersionEye](https://www.versioneye.com). By adding the license info to the gempspec it becomes available through the public RubyGems API and that way other tools like VersionEye can fetch it easier.